### PR TITLE
feat: adapt to tatris

### DIFF
--- a/docker/Dockerfiles/Dockerfile-dev
+++ b/docker/Dockerfiles/Dockerfile-dev
@@ -61,6 +61,8 @@ RUN mkdir -p /rally/.rally && \
 
 USER 1000
 
+RUN git clone https://github.com/tatris-io/rally-tracks.git /rally/.rally/benchmarks/tracks/tatris
+
 ENV PATH=/rally/venv/bin:$PATH
 
 LABEL org.label-schema.schema-version="1.0" \

--- a/docker/Dockerfiles/Dockerfile-release
+++ b/docker/Dockerfiles/Dockerfile-release
@@ -29,6 +29,8 @@ RUN mkdir -p /rally/.rally && \
 
 USER 1000
 
+RUN git clone https://github.com/tatris-io/rally-tracks.git /rally/.rally/benchmarks/tracks/tatris
+
 ENV PATH=/rally/venv/bin:$PATH
 
 LABEL org.label-schema.schema-version="1.0" \

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -720,7 +720,8 @@ class Driver:
         # ensure relative time starts when the benchmark starts.
         self.reset_relative_time()
         self.logger.info("Attaching cluster-level telemetry devices.")
-        self.telemetry.on_benchmark_start()
+        # TODO
+        # self.telemetry.on_benchmark_start()
         self.logger.info("Cluster-level telemetry devices are now attached.")
 
         allocator = Allocator(self.challenge.schedule)
@@ -791,7 +792,8 @@ class Driver:
             self.logger.debug("Postprocessing samples...")
             self.post_process_samples()
             if self.finished():
-                self.telemetry.on_benchmark_stop()
+                # TODO
+                # self.telemetry.on_benchmark_stop()
                 self.logger.info("All steps completed.")
                 # Some metrics store implementations return None because no external representation is required.
                 # pylint: disable=assignment-from-none

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1381,16 +1381,17 @@ async def set_destructive_requires_name(es, value):
     Sets `action.destructive_requires_name` to provided value
     :return: the prior setting, if any
     """
-    all_settings = await es.cluster.get_settings(flat_settings=True)
-    # If the setting was persistent or left as default, we consider resetting later with null sufficient
-    prior_value = all_settings.get("transient").get("action.destructive_requires_name")
-    settings_body = {
-        "transient": {
-            "action.destructive_requires_name": value,
-        },
-    }
-    await es.cluster.put_settings(body=settings_body)
-    return prior_value
+    # TODO Tatris does not support api '/_cluster/settings'
+    # all_settings = await es.cluster.get_settings(flat_settings=True)
+    # # If the setting was persistent or left as default, we consider resetting later with null sufficient
+    # prior_value = all_settings.get("transient").get("action.destructive_requires_name")
+    # settings_body = {
+    #     "transient": {
+    #         "action.destructive_requires_name": value,
+    #     },
+    # }
+    # await es.cluster.put_settings(body=settings_body)
+    return value
 
 
 class DeleteIndex(Runner):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -916,7 +916,8 @@ def create_default_reader(
 ):
     source = Slice(io.MmapSource, offset, num_lines)
     target = None
-    use_create = False
+    # Tatris only supports append data(bulk action=create)
+    use_create = True
     if docs.target_index:
         target = docs.target_index
     elif docs.target_data_stream:


### PR DESCRIPTION
- Due to github network reasons, track downloads are migrated to dockerfile
- The telemetry function will obtain node status, jvm information, etc. Currently, tatris does not have these capabilities.Block this function to ensure that the pressure test will not be terminated with an error in the middle
- Tatris only supports creating data, not updating data, so modify the bulk action to `create`